### PR TITLE
Include other CocoaScript file types

### DIFF
--- a/grammars/sketchplugin.cson
+++ b/grammars/sketchplugin.cson
@@ -1,6 +1,8 @@
 'fileTypes': [
   'sketchplugin',
-  'jstalk'
+  'jstalk',
+  'coscript',
+  'cocoascript'
 ]
 
 'name': 'JSTalk'


### PR DESCRIPTION
Updates the grammar to match for other CocoaScript file types beyond `.sketchplugin` and `.jstalk`.
